### PR TITLE
Simply by putting .nonzero before ||

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     attr_comparable (0.0.2)
-      minitest
 
 GEM
   remote: https://rubygems.org/
@@ -15,4 +14,5 @@ PLATFORMS
 
 DEPENDENCIES
   attr_comparable!
+  minitest
   rake (>= 0.9)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ Example Usage
 >> junior = FullName.new("John", "Q.", "Public", "Jr.")
 >> junior > dad
 => true
->> [mom, dad, junior].sort.map &:to_s
+>> [junior, mom, dad].sort.map &:to_s
 => ["Kathy Doe", "John Q. Public", "John Q. Public, Jr."]
 ```

--- a/attr_comparable.gemspec
+++ b/attr_comparable.gemspec
@@ -1,7 +1,7 @@
 require File.expand_path('../lib/attr_comparable/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'minitest' # Included in Ruby 1.9, but we want the latest.
+  gem.add_development_dependency 'minitest' # Included in Ruby 1.9, but we want the latest.
   gem.add_development_dependency 'rake', '>=0.9'
 
   gem.authors       = ["Colin Kelley"]

--- a/lib/attr_comparable.rb
+++ b/lib/attr_comparable.rb
@@ -27,11 +27,8 @@ module AttrComparable
       EOS
     end
 
-    def attr_compare(*attributes_arg)
-      attributes = attributes_arg.flatten
-
-      remaining_attrs = attributes.size;
-      attr_exprs = attributes.map do |attribute|
+    def attr_compare(*attributes)
+      attr_exprs = (attributes.flatten).map do |attribute|
         '(' + compare_with_nil_code("self.#{attribute}", "rhs.#{attribute}").strip + ')'
       end
 


### PR DESCRIPTION
@jpterry  Can you review? I realized in looking at your PR that I could have handled the `.nonzero?` special case on the outside in just one place, in front of `||`.
